### PR TITLE
Make RangeIntGenerator Thread Safe

### DIFF
--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/random/RangeIntGenerator.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/random/RangeIntGenerator.java
@@ -45,7 +45,7 @@ class RangeIntGenerator implements IntGenerator {
     }
 
     @Override
-    public int next(Random random, int idx, int all) {
+    public synchronized int next(Random random, int idx, int all) {
     	int range = upper - lower + 1;
     	int base = range / all;
     	int extra = range % all;


### PR DESCRIPTION
Make RangeIntGenerator Thread Safe, before it would give some numbers multiple times, before.
