### PR TITLE
Start Script Non-TTY Support

### DIFF
--- a/release/cosbench-start.sh
+++ b/release/cosbench-start.sh
@@ -43,7 +43,7 @@ mkdir -p log
 
 echo "Launching osgi framwork ... "
 
-java -Dcosbench.tomcat.config=$TOMCAT_CONFIG -server -cp main/* org.eclipse.equinox.launcher.Main -configuration $OSGI_CONFIG -console $OSGI_CONSOLE_PORT >> $BOOT_LOG &
+/usr/bin/nohup java -Dcosbench.tomcat.config=$TOMCAT_CONFIG -server -cp main/* org.eclipse.equinox.launcher.Main -configuration $OSGI_CONFIG -console $OSGI_CONSOLE_PORT 1> $BOOT_LOG 2>&1 &
 
 if [ $? -ne 0 ];
 then


### PR DESCRIPTION
Modifies cosbench-start.sh to start Java using nohup and redirectstderr to stdin to ensure the process starts without hanging in non-tty environments
