### PR TITLE
Issue #143: loading archived workloads errors appear when some workloads...

### DIFF
--- a/dev/cosbench-controller/src/com/intel/cosbench/controller/repository/SimpleWorkloadList.java
+++ b/dev/cosbench-controller/src/com/intel/cosbench/controller/repository/SimpleWorkloadList.java
@@ -51,7 +51,7 @@ class SimpleWorkloadList implements WorkloadList {
     public WorkloadContext[] add(WorkloadContext workload) {
         toBeRemoved.clear(); // begin transaction
         list.put(workload.getId(), workload);
-        capacity += 1;
+        capacity = count(); // size of list	
         shrinkListSize();
         WorkloadContext[] result = new WorkloadContext[toBeRemoved.size()];
         result = toBeRemoved.toArray(result);

--- a/dev/cosbench-controller/src/com/intel/cosbench/controller/service/COSBControllerService.java
+++ b/dev/cosbench-controller/src/com/intel/cosbench/controller/service/COSBControllerService.java
@@ -58,7 +58,6 @@ class COSBControllerService implements ControllerService, WorkloadListener {
     private WorkloadRepository memRepo = new RAMWorkloadRepository();
     
     private boolean loadArch = false;
-    private boolean loaded = false;
 
     public COSBControllerService() {
         /* empty */
@@ -96,7 +95,6 @@ class COSBControllerService implements ControllerService, WorkloadListener {
 			return;
 		for (WorkloadInfo workloadContext : workloadContexts)
 			memRepo.saveWorkload((WorkloadContext) workloadContext);
-		loaded = true;
 	}
 	
 	public void unloadArchivedWorkload() {
@@ -104,7 +102,6 @@ class COSBControllerService implements ControllerService, WorkloadListener {
 			memRepo.removeWorkload(workload);
 			workload = null;
 		}
-		loaded = false;
 	}
 	
 
@@ -153,12 +150,15 @@ class COSBControllerService implements ControllerService, WorkloadListener {
     public void setloadArch(boolean loadArch) {
     	this.loadArch = loadArch;
     	
-    	if(getloadArch() && !loaded)
+    	if(getloadArch()){
 			try {
 				loadArchivedWorkload();
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
+    	} else {
+    		unloadArchivedWorkload();
+    	}
     }
     
     private String generateWorkloadId() {


### PR DESCRIPTION
1. change "capacity" to be the same as the count of workloads in RAM.
2. delete variable "loaded" which is unnecessary. Thus the program will load archived workloads from run-history.csv instead of loading from RAM.
