### PR TITLE
small fixes to httpauth

### DIFF
--- a/dev/cosbench-httpauth/META-INF/spring/plugin-context.xml
+++ b/dev/cosbench-httpauth/META-INF/spring/plugin-context.xml
@@ -8,7 +8,7 @@
          http://www.springframework.org/schema/osgi
          http://www.springframework.org/schema/osgi/spring-osgi.xsd">
 
-	<bean name="storageFactory" class="com.intel.cosbench.api.httpauth.HttpAuthFactory" />
+	<bean name="authFactory" class="com.intel.cosbench.api.httpauth.HttpAuthFactory" />
 
 	<osgi:service ref="authFactory" context-class-loader="service-provider"
 		interface="com.intel.cosbench.api.auth.AuthAPIFactory">

--- a/dev/cosbench-httpauth/src/com/intel/cosbench/api/httpauth/HttpAuth.java
+++ b/dev/cosbench-httpauth/src/com/intel/cosbench/api/httpauth/HttpAuth.java
@@ -104,12 +104,6 @@ class HttpAuth extends NoneAuth {
     }
     
     @Override
-    public void dispose() {
-        super.dispose();
-        HttpClientUtil.disposeHttpClient(client);
-    }
-    
-    @Override
     public AuthContext login() {
         super.login();
 


### PR DESCRIPTION
A couple fixes I needed to make httpauth work for me with the CDMI adapter
- wrong bean name in plugin-context.xml
- HttpAuth must not dispose of the HTTP client instance
  as it stores it in the context for later use
