### PR TITLE
fixed issue: after generating workload config files from advanced config...

### DIFF
--- a/dev/cosbench-controller-web/src/com/intel/cosbench/controller/web/WorkloadConfigGenerator.java
+++ b/dev/cosbench-controller-web/src/com/intel/cosbench/controller/web/WorkloadConfigGenerator.java
@@ -105,6 +105,7 @@ public class WorkloadConfigGenerator {
 			workload.validate();
 				
 			String workloadName = req.getParameterValues("workload.name")[workloadNumber];
+			workload.setName(workloadName);
 			
 			if (generateWorkloadFiles)
 				{
@@ -118,7 +119,6 @@ public class WorkloadConfigGenerator {
 				}
 			else
 			{
-				workload.setName(workloadName);
 				submitWorkload(workload);
 			}
 		}


### PR DESCRIPTION
... UI, workload name attribute value inside workload config file was not getting changed as per the value entered by user
