### PR TITLE
get report for cancelled/terminated stage 

### DIFF
--- a/dev/cosbench-controller/src/com/intel/cosbench/controller/tasklet/Aborter.java
+++ b/dev/cosbench-controller/src/com/intel/cosbench/controller/tasklet/Aborter.java
@@ -19,6 +19,8 @@ package com.intel.cosbench.controller.tasklet;
 
 import static com.intel.cosbench.model.TaskState.*;
 
+import com.intel.cosbench.bench.Metrics;
+import com.intel.cosbench.bench.Report;
 import com.intel.cosbench.controller.model.TaskContext;
 import com.intel.cosbench.protocol.AbortResponse;
 
@@ -61,6 +63,10 @@ class Aborter extends AbstractCommandTasklet<AbortResponse> {
 
     @Override
     protected void handleResponse(AbortResponse response) {
+    	Report report = new Report();
+        for (Metrics metrics : response.getReport())
+            report.addMetrics(metrics);
+        context.setReport(report);
         context.setLog(response.getDriverLog());
     }
 

--- a/dev/cosbench-core/src/com/intel/cosbench/protocol/AbortResponse.java
+++ b/dev/cosbench-core/src/com/intel/cosbench/protocol/AbortResponse.java
@@ -17,6 +17,10 @@ limitations under the License.
 
 package com.intel.cosbench.protocol;
 
+import java.util.List;
+
+import com.intel.cosbench.bench.Metrics;
+
 
 /**
  * The response to get log from driver when aborted.
@@ -27,6 +31,7 @@ package com.intel.cosbench.protocol;
 public class AbortResponse extends Response {
 
     private String driverLog; /* driver log */
+    private List<Metrics> report; /* metrics report */
 
     public AbortResponse() {
         /* empty */
@@ -38,6 +43,14 @@ public class AbortResponse extends Response {
 
     public void setDriverLog(String driverLog) {
         this.driverLog = driverLog;
+    }
+    
+    public List<Metrics> getReport() {
+        return report;
+    }
+
+    public void setReport(List<Metrics> report) {
+        this.report = report;
     }
 
 }

--- a/dev/cosbench-driver-web/src/com/intel/cosbench/driver/handler/AbortHandler.java
+++ b/dev/cosbench-driver-web/src/com/intel/cosbench/driver/handler/AbortHandler.java
@@ -18,7 +18,9 @@ limitations under the License.
 package com.intel.cosbench.driver.handler;
 
 import java.io.IOException;
+import java.util.Arrays;
 
+import com.intel.cosbench.bench.Report;
 import com.intel.cosbench.model.MissionInfo;
 import com.intel.cosbench.protocol.*;
 
@@ -33,6 +35,8 @@ public class AbortHandler extends MissionHandler {
 
     private Response getResponse(MissionInfo info) {
         AbortResponse response = new AbortResponse();
+        Report report = info.getReport();
+        response.setReport(Arrays.asList(report.getAllMetrics()));
         String log = null;
         try {
             log = info.getLogManager().getLogAsString();


### PR DESCRIPTION
enable reports collecting for cancelled/terminated stage, in case of non-report of a  workload which was cancelled/terminated after a long run. 
