### PR TITLE
Fix #270: S3 timeout parameter modifies both connection and inactivity timeouts

### DIFF
--- a/dev/cosbench-s3/src/com/intel/cosbench/api/S3Stor/S3Storage.java
+++ b/dev/cosbench-s3/src/com/intel/cosbench/api/S3Stor/S3Storage.java
@@ -53,6 +53,7 @@ public class S3Storage extends NoneStorage {
         
         ClientConfiguration clientConf = new ClientConfiguration();
         clientConf.setConnectionTimeout(timeout);
+        clientConf.setSocketTimeout(timeout);
 //        clientConf.setProtocol(Protocol.HTTP);
 		if((!proxyHost.equals(""))&&(!proxyPort.equals(""))){
 			clientConf.setProxyHost(proxyHost);


### PR DESCRIPTION
[Trivial change] Makes the S3 timeout parameter specified in XML workload, apply to both socket connect, and socket inactivity timeouts.