### PR TITLE
Replace System.currentTimeMillis() by System.nanoTime()

### DIFF
--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/generator/XferCountingInputStream.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/generator/XferCountingInputStream.java
@@ -42,14 +42,14 @@ public class XferCountingInputStream extends CountingInputStream{
 	
 	private void recordTime() {
 		if (this.isFirstByte) {
-			this.xferStart = System.currentTimeMillis();
+			this.xferStart = System.nanoTime();
 			this.isFirstByte = false;
 		}
-		this.xferEnd = System.currentTimeMillis();
+		this.xferEnd = System.nanoTime();
 	}
 	
 	public long getXferTime() {
-		long xferTime = this.xferEnd - this.xferStart;
+		long xferTime = (this.xferEnd - this.xferStart) / 1000000;
 		return xferTime > 0 ? xferTime : 0L;
 	}
 	

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Deleter.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Deleter.java
@@ -69,7 +69,7 @@ class Deleter extends AbstractOperator {
         if (Thread.interrupted())
             throw new AbortedException();
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         try {
             session.getApi().deleteObject(conName, objName, config);
@@ -87,11 +87,10 @@ class Deleter extends AbstractOperator {
 					op.getSampleType(), op.getName(), false);
         }
 
-        long end = System.currentTimeMillis();
+        long end = System.nanoTime();
 
-        Date now = new Date(end);
-        return new Sample(now, op.getId(), op.getOpType(), op.getSampleType(),
-				op.getName(), true, end - start, 0L, 0L);
+        return new Sample(new Date(), op.getId(), op.getOpType(), op.getSampleType(),
+				op.getName(), true, (end - start) / 1000000, 0L, 0L);
     }
 
 }

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/FileWriter.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/FileWriter.java
@@ -147,7 +147,7 @@ class FileWriter extends AbstractOperator {
 
         XferCountingInputStream cin = new XferCountingInputStream(in);
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         try {
               session.getApi().createObject(conName, objName, cin, length, config);
@@ -163,10 +163,9 @@ class FileWriter extends AbstractOperator {
             IOUtils.closeQuietly(cin);
         }
 
-        long end = System.currentTimeMillis();
+        long end = System.nanoTime();
 
-        Date now = new Date(end);
-        return new Sample(now,  getId(), getOpType(), getSampleType(),
-				getName(), true, end - start, cin.getXferTime(), cin.getByteCount());
+        return new Sample(new Date(),  getId(), getOpType(), getSampleType(),
+				getName(), true, (end - start) / 1000000, cin.getXferTime(), cin.getByteCount());
     }
 }

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Lister.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Lister.java
@@ -75,14 +75,14 @@ public class Lister extends AbstractOperator {
         InputStream in = null;
         CountingOutputStream cout = new CountingOutputStream(out);
         doLogWarn(session.getLogger(), "listerrr: "+ conName + "/" + objName);//###
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         long xferTime = 0L;
         try {
         	doLogDebug(session.getLogger(), "worker "+ session.getIndex() + " List target " + conName + "/" + objName);      	
 	        in = session.getApi().getList(conName, objName, config);
-	        long xferStart = System.currentTimeMillis();
+	        long xferStart = System.nanoTime();
 	        copyLarge(in, cout);
-	        xferTime = System.currentTimeMillis() - xferStart;
+	        xferTime = (System.nanoTime() - xferStart) / 1000000;
         } catch (StorageInterruptedException sie) {
             doLogErr(session.getLogger(), sie.getMessage(), sie);
             throw new AbortedException();
@@ -95,11 +95,10 @@ public class Lister extends AbstractOperator {
             IOUtils.closeQuietly(in);
             IOUtils.closeQuietly(cout);
         }
-        long end = System.currentTimeMillis();
+        long end = System.nanoTime();
 
-        Date now = new Date(end);
-		return new Sample(now, getId(), getOpType(), getSampleType(),
-				getName(), true, end - start, xferTime, cout.getByteCount());
+		return new Sample(new Date(), getId(), getOpType(), getSampleType(),
+				getName(), true, (end - start) / 1000000, xferTime, cout.getByteCount());
     }
 
     public OutputStream copyLarge(InputStream input, OutputStream output)

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Reader.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Reader.java
@@ -82,19 +82,19 @@ class Reader extends AbstractOperator {
         InputStream in = null;
         CountingOutputStream cout = new CountingOutputStream(out);
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         long xferTime = 0L;
-        long xferTimeCheck = 0L;
         try {
             in = session.getApi().getObject(conName, objName, config);
-            long xferStart = System.currentTimeMillis();
-            if (!hashCheck){
+            long xferStart = System.nanoTime();
+            if (!hashCheck) {
                 copyLarge(in, cout);
-            	long xferEnd = System.currentTimeMillis();
-            	xferTime = xferEnd - xferStart;
-            } else if (!validateChecksum(conName, objName, session, in, cout, xferTimeCheck))
+            } else if (!validateChecksum(conName, objName, session, in, cout)) {
 				return new Sample(new Date(), getId(), getOpType(),
 						getSampleType(), getName(), false);
+            }
+            long xferEnd = System.nanoTime();
+            xferTime = (xferEnd - xferStart) / 1000000;
         } catch (StorageInterruptedException sie) {
             doLogErr(session.getLogger(), sie.getMessage(), sie);
             throw new AbortedException();
@@ -107,11 +107,11 @@ class Reader extends AbstractOperator {
             IOUtils.closeQuietly(in);
             IOUtils.closeQuietly(cout);
         }
-        long end = System.currentTimeMillis();
+        long end = System.nanoTime();
 
-        Date now = new Date(end);
-		return new Sample(now, getId(), getOpType(), getSampleType(),
-				getName(), true, end - start, hashCheck ? xferTimeCheck : xferTime, cout.getByteCount());
+		return new Sample(new Date(), getId(), getOpType(), getSampleType(),
+				getName(), true, (end - start)/1000000,
+				xferTime, cout.getByteCount());
     }
 
     public OutputStream copyLarge(InputStream input, OutputStream output)
@@ -126,7 +126,7 @@ class Reader extends AbstractOperator {
     }
     
     private static boolean validateChecksum(String conName, String objName,
-            Session session, InputStream in, OutputStream out, long xferTimeCheck)
+            Session session, InputStream in, OutputStream out)
             throws IOException {
         HashUtil util;
         try {
@@ -139,7 +139,6 @@ class Reader extends AbstractOperator {
             String storedHash = new String();
             String calculatedHash = new String();
             
-            long xferStart = System.currentTimeMillis();
             int br1 = in.read(buf1);
 
             if (br1 <= hashLen) {
@@ -176,8 +175,7 @@ class Reader extends AbstractOperator {
                     br1 = br2;
                 }
             }
-            xferTimeCheck = System.currentTimeMillis() - xferStart;
-            
+
             if (!calculatedHash.equals(storedHash)) {
                 if (storedHash.startsWith(HashUtil.GUARD)) {
                     String err =

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Writer.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Writer.java
@@ -91,7 +91,7 @@ class Writer extends AbstractOperator {
             throw new AbortedException();
         
         XferCountingInputStream cin = new XferCountingInputStream(in);	
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         try {
             session.getApi()
@@ -110,10 +110,10 @@ class Writer extends AbstractOperator {
             IOUtils.closeQuietly(cin);
         }
 
-        long end = System.currentTimeMillis();
-        Date now = new Date(end);
-		return new Sample(now, op.getId(), op.getOpType(), op.getSampleType(),
-				op.getName(), true, end - start, cin.getXferTime(), cin.getByteCount());
+        long end = System.nanoTime();
+		return new Sample(new Date(), op.getId(), op.getOpType(), op.getSampleType(),
+				op.getName(), true, (end - start) / 1000000,
+				cin.getXferTime(), cin.getByteCount());
     }
     /*
      * public static Sample doWrite(byte[] data, String conName, String objName,


### PR DESCRIPTION
Fix #206 #264.

System.currentTimeMillis() is not monotonic and a second call
may return a value inferior to the first call if the system
time changes between the 2 calls. This is why we got negative
durations from time to time. Using System.nanoTime() should
prevent this problem.