### PR TITLE
Get rid of 100-continue overhead

### DIFF
--- a/dev/cosbench-s3/src/com/intel/cosbench/api/S3Stor/S3Storage.java
+++ b/dev/cosbench-s3/src/com/intel/cosbench/api/S3Stor/S3Storage.java
@@ -54,6 +54,7 @@ public class S3Storage extends NoneStorage {
         ClientConfiguration clientConf = new ClientConfiguration();
         clientConf.setConnectionTimeout(timeout);
         clientConf.setSocketTimeout(timeout);
+        clientConf.withUseExpectContinue(false);
 //        clientConf.setProtocol(Protocol.HTTP);
 		if((!proxyHost.equals(""))&&(!proxyPort.equals(""))){
 			clientConf.setProxyHost(proxyHost);


### PR DESCRIPTION
aws s3 java sdk sends request header "Expect: 100-continue" in default. It causes additional handshake and is unnecessary overhead during benchmark. Disable it to get rid of the overhead.