### PR TITLE
fix bug: function errorStatisticsHandle and doAdd throw unexpected exception

### DIFF
--- a/dev/cosbench-controller/src/com/intel/cosbench/controller/service/WorkloadProcessor.java
+++ b/dev/cosbench-controller/src/com/intel/cosbench/controller/service/WorkloadProcessor.java
@@ -207,7 +207,7 @@ class WorkloadProcessor {
 
 			long elapsedTime = System.currentTimeMillis() - startStamp;
 
-			LOGGER.info("END WORK:   {}, Time elapsed: {}", stageName, millisToHMS(elapsedTime));
+			LOGGER.info("END WORK:   {}, Time elapsed: {}", stageName, millisToHMS(elapsedTime > 0 ? elapsedTime : 0L));
 			LOGGER.info("============================================");
 			if(closuredelay > 0)
 				executeDelay(stageContext, closuredelay);

--- a/dev/cosbench-core/src/com/intel/cosbench/bench/Counter.java
+++ b/dev/cosbench-core/src/com/intel/cosbench/bench/Counter.java
@@ -62,6 +62,7 @@ public class Counter {
      */
     public void doAdd(long time) {
         int index = (time >= RES_MAX) ? UL : (int) (time / RES_INT);
+        index = index < 0 ? 0 : index;
         counts[index].incrementAndGet();
     }
 

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Deleter.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Deleter.java
@@ -69,7 +69,7 @@ class Deleter extends AbstractOperator {
         if (Thread.interrupted())
             throw new AbortedException();
 
-        long start = System.currentTimeMillis();
+        long start = getCurrentTimeMillis();
 
         try {
             session.getApi().deleteObject(conName, objName, config);
@@ -87,10 +87,9 @@ class Deleter extends AbstractOperator {
 					op.getSampleType(), op.getName(), false);
         }
 
-        long end = System.currentTimeMillis();
+        long end = getCurrentTimeMillis();
 
-        Date now = new Date(end);
-        return new Sample(now, op.getId(), op.getOpType(), op.getSampleType(),
+        return new Sample(new Date(), op.getId(), op.getOpType(), op.getSampleType(),
 				op.getName(), true, end - start, 0L, 0L);
     }
 

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/FileWriter.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/FileWriter.java
@@ -147,7 +147,7 @@ class FileWriter extends AbstractOperator {
 
         XferCountingInputStream cin = new XferCountingInputStream(in);
 
-        long start = System.currentTimeMillis();
+        long start = getCurrentTimeMillis();
 
         try {
               session.getApi().createObject(conName, objName, cin, length, config);
@@ -163,10 +163,9 @@ class FileWriter extends AbstractOperator {
             IOUtils.closeQuietly(cin);
         }
 
-        long end = System.currentTimeMillis();
+        long end = getCurrentTimeMillis();
 
-        Date now = new Date(end);
-        return new Sample(now,  getId(), getOpType(), getSampleType(),
+        return new Sample(new Date(),  getId(), getOpType(), getSampleType(),
 				getName(), true, end - start, cin.getXferTime(), cin.getByteCount());
     }
 }

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Lister.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Lister.java
@@ -75,14 +75,14 @@ public class Lister extends AbstractOperator {
         InputStream in = null;
         CountingOutputStream cout = new CountingOutputStream(out);
         doLogWarn(session.getLogger(), "listerrr: "+ conName + "/" + objName);//###
-        long start = System.currentTimeMillis();
+        long start = getCurrentTimeMillis();
         long xferTime = 0L;
         try {
         	doLogDebug(session.getLogger(), "worker "+ session.getIndex() + " List target " + conName + "/" + objName);      	
 	        in = session.getApi().getList(conName, objName, config);
-	        long xferStart = System.currentTimeMillis();
+	        long xferStart = getCurrentTimeMillis();
 	        copyLarge(in, cout);
-	        xferTime = System.currentTimeMillis() - xferStart;
+	        xferTime = getCurrentTimeMillis() - xferStart;
         } catch (StorageInterruptedException sie) {
             doLogErr(session.getLogger(), sie.getMessage(), sie);
             throw new AbortedException();
@@ -95,10 +95,9 @@ public class Lister extends AbstractOperator {
             IOUtils.closeQuietly(in);
             IOUtils.closeQuietly(cout);
         }
-        long end = System.currentTimeMillis();
+        long end = getCurrentTimeMillis();
 
-        Date now = new Date(end);
-		return new Sample(now, getId(), getOpType(), getSampleType(),
+		return new Sample(new Date(), getId(), getOpType(), getSampleType(),
 				getName(), true, end - start, xferTime, cout.getByteCount());
     }
 

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Reader.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Reader.java
@@ -82,15 +82,15 @@ class Reader extends AbstractOperator {
         InputStream in = null;
         CountingOutputStream cout = new CountingOutputStream(out);
 
-        long start = System.currentTimeMillis();
+        long start = getCurrentTimeMillis();
         long xferTime = 0L;
         long xferTimeCheck = 0L;
         try {
             in = session.getApi().getObject(conName, objName, config);
-            long xferStart = System.currentTimeMillis();
+            long xferStart = getCurrentTimeMillis();
             if (!hashCheck){
                 copyLarge(in, cout);
-            	long xferEnd = System.currentTimeMillis();
+                long xferEnd = getCurrentTimeMillis();
             	xferTime = xferEnd - xferStart;
             } else if (!validateChecksum(conName, objName, session, in, cout, xferTimeCheck))
 				return new Sample(new Date(), getId(), getOpType(),
@@ -107,7 +107,7 @@ class Reader extends AbstractOperator {
             IOUtils.closeQuietly(in);
             IOUtils.closeQuietly(cout);
         }
-        long end = System.currentTimeMillis();
+        long end = getCurrentTimeMillis();
 
         Date now = new Date(end);
 		return new Sample(now, getId(), getOpType(), getSampleType(),
@@ -139,7 +139,7 @@ class Reader extends AbstractOperator {
             String storedHash = new String();
             String calculatedHash = new String();
             
-            long xferStart = System.currentTimeMillis();
+            long xferStart = getCurrentTimeMillis();
             int br1 = in.read(buf1);
 
             if (br1 <= hashLen) {
@@ -176,7 +176,7 @@ class Reader extends AbstractOperator {
                     br1 = br2;
                 }
             }
-            xferTimeCheck = System.currentTimeMillis() - xferStart;
+            xferTimeCheck = getCurrentTimeMillis() - xferStart;
             
             if (!calculatedHash.equals(storedHash)) {
                 if (storedHash.startsWith(HashUtil.GUARD)) {

--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Writer.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/Writer.java
@@ -91,7 +91,7 @@ class Writer extends AbstractOperator {
             throw new AbortedException();
         
         XferCountingInputStream cin = new XferCountingInputStream(in);	
-        long start = System.currentTimeMillis();
+        long start = getCurrentTimeMillis();
 
         try {
             session.getApi()
@@ -110,9 +110,8 @@ class Writer extends AbstractOperator {
             IOUtils.closeQuietly(cin);
         }
 
-        long end = System.currentTimeMillis();
-        Date now = new Date(end);
-		return new Sample(now, op.getId(), op.getOpType(), op.getSampleType(),
+        long end = getCurrentTimeMillis();
+		return new Sample(new Date(), op.getId(), op.getOpType(), op.getSampleType(),
 				op.getName(), true, end - start, cin.getXferTime(), cin.getByteCount());
     }
     /*

--- a/dev/cosbench-librados/.classpath
+++ b/dev/cosbench-librados/.classpath
@@ -6,11 +6,6 @@
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="lib" path="rados.jar"/>
 	<classpathentry kind="lib" path="jna-3.5.2.jar"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/cosbench-api"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/cosbench-config"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/cosbench-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/cosbench-log"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/cosbench-log4j"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/cosbench-librados/META-INF/MANIFEST.MF
+++ b/dev/cosbench-librados/META-INF/MANIFEST.MF
@@ -15,3 +15,6 @@ import-Package: com.intel.cosbench.api.auth,
  com.intel.cosbench.config,
  com.intel.cosbench.config.common,
  com.intel.cosbench.log
+Require-Bundle: cosbench-api,
+ cosbench-log,
+ cosbench-config


### PR DESCRIPTION
three bug is fixed:

1.  unexpected exception cause cosbench throw StringIndexOutOfBoundsException:

```
2020-02-26 11:57:07,099 [ERROR] [AbstractAgent] - unexpected exception
java.lang.StringIndexOutOfBoundsException: String index out of range: 12
        at java.lang.String.substring(String.java:1963)
        at com.intel.cosbench.driver.operator.AbstractOperator.isUnauthorizedException(AbstractOperator.java:134)
        at com.intel.cosbench.driver.operator.Reader.doRead(Reader.java:102)
        at com.intel.cosbench.driver.operator.Reader.operate(Reader.java:69)
```

2.  time hopping cause cosbench throw  ArrayIndexOutOfBoundsException:

```
2020-02-28 12:16:55,205 [ERROR] [AbstractAgent] - unexpected exception
java.lang.ArrayIndexOutOfBoundsException: -270
        at com.intel.cosbench.bench.Counter.doAdd(Counter.java:65)
        at com.intel.cosbench.driver.model.OperatorContext.doAddSample(OperatorContext.java:76)
        at com.intel.cosbench.driver.model.OperatorContext.addSample(OperatorContext.java:70)

```
3.  emtpy stack cause cosbench throw ArrayIndexOutOfBoundsException:

```
2020-02-28 23:27:57,462 [ERROR] [AbstractAgent] - unexpected exception
java.lang.ArrayIndexOutOfBoundsException: 0
        at com.intel.cosbench.driver.operator.AbstractOperator.errorStatisticsHandle(AbstractOperator.java:117)
        at com.intel.cosbench.driver.operator.Writer.doWrite(Writer.java:104)
        at com.intel.cosbench.driver.operator.Preparer.operate(Preparer.java:97)
```