### PR TITLE
Remove CORBA references, and resolve #412

### DIFF
--- a/dev/cosbench-http/src/com/intel/cosbench/client/http/HttpClientUtil.java
+++ b/dev/cosbench-http/src/com/intel/cosbench/client/http/HttpClientUtil.java
@@ -48,7 +48,6 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 import org.apache.http.protocol.HttpContext;
-import org.omg.CORBA.PUBLIC_MEMBER;
 
 /**
  * This class encapsulates basic HTTP client related functions which are


### PR DESCRIPTION
This PR resolves #412  and make it possible to build COSBench Java11 and later.
