### PR TITLE
Remove the wrong source path(cosbench-openio/test).

### DIFF
--- a/dev/cosbench-openio/.classpath
+++ b/dev/cosbench-openio/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="gson-2.5.jar"/>


### PR DESCRIPTION
Remove an unnecessary path element from dev/cosbench-openio/.classpath, and fixe #414 .

This work is a part of works done by @Nathaniel7687 in 2018.
As the chunk works now as is, I cherry-picked his commit to honor him.
